### PR TITLE
exec: clone task process directly into its cgroup

### DIFF
--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -146,3 +146,16 @@ func TestBasic_Passwd(t *testing.T) {
 	stopOutput := run(t, ctx, "nomad", "job", "stop", "-purge", "passwd")
 	must.StrContains(t, stopOutput, `finished with status "complete"`)
 }
+
+func TestBasic_Cgroup(t *testing.T) {
+	ctx := setup(t)
+
+	_ = run(t, ctx, "nomad", "job", "run", "../hack/cgroup.hcl")
+	statusOutput := run(t, ctx, "nomad", "job", "status", "cgroup")
+
+	alloc := allocFromJobStatus(t, statusOutput)
+	cgroupRe := regexp.MustCompile(`0::/nomad\.slice/` + alloc + `.+\.cat\.scope`)
+
+	logs := run(t, ctx, "nomad", "alloc", "logs", alloc)
+	must.RegexMatch(t, cgroupRe, logs)
+}

--- a/hack/cgroup.hcl
+++ b/hack/cgroup.hcl
@@ -1,0 +1,15 @@
+job "cgroup" {
+  type = "sysbatch"
+
+  group "group" {
+    task "cat" {
+      driver = "pledge"
+      config {
+        command  = "/bin/cat"
+        args     = ["/proc/self/cgroup"]
+        promises = "stdio rpath"
+        unveil   = ["r:/proc/self/cgroup"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR changes the exec of the task child process to belong to its
own cgroup during its creation, fixing the race condition of moving
the PID into the cgroup after starting.

Adds new e2e test asserting the child process is launched in its own
cgroup.

Fixes #2

Closes #1 (no longer need supervisor process)