### PR TITLE
plugin: support for bridge networking, pid/ipc namespacing

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,6 +19,11 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo dd of=/etc/apt/sources.list.d/hashicorp.list
           sudo apt update && sudo apt install nomad
           nomad version
+      - name: Install CNI
+        run: |
+          mkdir -p /opt/cni/bin
+          curl -L -o cni.tgz "https://github.com/containernetworking/plugins/releases/download/v1.3.0/cni-plugins-linux-amd64-v1.3.0.tgz"
+          tar -C /opt/cni/bin -xf cni.tgz
       - name: Install Plugin
         run: |
           make dev

--- a/hack/bridge.hcl
+++ b/hack/bridge.hcl
@@ -1,0 +1,53 @@
+job "bridge" {
+  group "group" {
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+
+    update {
+      min_healthy_time = "2s"
+    }
+
+    network {
+      mode = "bridge"
+      port "http" { to = 8181 }
+    }
+
+    service {
+      provider = "nomad"
+      name = "pybridge"
+      port = "http"
+      check {
+        name = "up"
+        type = "http"
+        path = "/index.html"
+        interval = "6s"
+        timeout = "1s"
+      }
+    }
+
+    task "python" {
+      driver = "pledge"
+      user   = "nobody"
+      config {
+        command  = "python3"
+        args     = ["-m", "http.server", "8181", "--directory", "${NOMAD_TASK_DIR}"]
+        promises = "stdio rpath inet"
+        unveil   = ["r:/etc/mime.types", "r:${NOMAD_TASK_DIR}"]
+      }
+
+
+      template {
+        destination = "local/index.html"
+        data        = <<EOH
+<!doctype html>
+<html>
+  <title>bridge mode</title>
+  <body><p>Hello, pal!</p></body>
+</html>
+EOH
+      }
+    }
+  }
+}

--- a/hack/ps.hcl
+++ b/hack/ps.hcl
@@ -1,0 +1,16 @@
+job "ps" {
+  type = "batch"
+
+  group "group" {
+    task "ps" {
+      driver = "pledge"
+      user   = "root"
+      config {
+        command  = "ps"
+        args     = ["aux"]
+        promises = "stdio rpath exec"
+        unveil   = ["r:/proc"]
+      }
+    }
+  }
+}

--- a/pkg/plugin/about.go
+++ b/pkg/plugin/about.go
@@ -46,10 +46,14 @@ var capabilities = &drivers.Capabilities{
 	SendSignals:         true,
 	Exec:                false,
 	FSIsolation:         drivers.FSIsolationNone,
-	NetIsolationModes:   []drivers.NetIsolationMode{drivers.NetIsolationModeNone},
 	MustInitiateNetwork: false,
 	MountConfigs:        drivers.MountConfigSupportAll,
 	RemoteTasks:         false,
+	NetIsolationModes: []drivers.NetIsolationMode{
+		drivers.NetIsolationModeNone,
+		drivers.NetIsolationModeHost,
+		drivers.NetIsolationModeGroup,
+	},
 }
 
 // Config represents the pledge-driver plugin configuration that gets set in the

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -195,6 +195,19 @@ func open(stdout, stderr string) (io.WriteCloser, io.WriteCloser, error) {
 	return a, b, nil
 }
 
+func netns(c *drivers.TaskConfig) string {
+	switch {
+	case c == nil:
+		return ""
+	case c.NetworkIsolation == nil:
+		return ""
+	case c.NetworkIsolation.Mode == drivers.NetIsolationModeGroup:
+		return c.NetworkIsolation.Path
+	default:
+		return ""
+	}
+}
+
 func (p *PledgeDriver) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandle, *drivers.DriverNetwork, error) {
 	if config.User == "" {
 		config.User = "nobody"
@@ -223,6 +236,7 @@ func (p *PledgeDriver) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandl
 		Dir:    config.TaskDir().Dir,
 		User:   config.User,
 		Cgroup: p.cgroup(config.AllocID, config.Name),
+		Net:    netns(config),
 	}
 
 	opts, err := parseOptions(config)


### PR DESCRIPTION
This PR adds support for running jobs making use of bridge networking.
Also now runs processes inside an isolated PID and IPC namespace, similar
to the default behavior of the exec, docker, and podman drivers.
