### PR TITLE
hack: tidy up hcl example files

### DIFF
--- a/hack/bridge.hcl
+++ b/hack/bridge.hcl
@@ -1,14 +1,5 @@
 job "bridge" {
   group "group" {
-    restart {
-      attempts = 0
-      mode     = "fail"
-    }
-
-    update {
-      min_healthy_time = "2s"
-    }
-
     network {
       mode = "bridge"
       port "http" { to = 8181 }
@@ -16,14 +7,14 @@ job "bridge" {
 
     service {
       provider = "nomad"
-      name = "pybridge"
-      port = "http"
+      name     = "pybridge"
+      port     = "http"
       check {
-        name = "up"
-        type = "http"
-        path = "/index.html"
+        name     = "up"
+        type     = "http"
+        path     = "/index.html"
         interval = "6s"
-        timeout = "1s"
+        timeout  = "1s"
       }
     }
 
@@ -37,7 +28,6 @@ job "bridge" {
         unveil   = ["r:/etc/mime.types", "r:${NOMAD_TASK_DIR}"]
       }
 
-
       template {
         destination = "local/index.html"
         data        = <<EOH
@@ -48,6 +38,15 @@ job "bridge" {
 </html>
 EOH
       }
+    }
+
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+
+    update {
+      min_healthy_time = "2s"
     }
   }
 }

--- a/hack/cgroup.hcl
+++ b/hack/cgroup.hcl
@@ -1,5 +1,5 @@
 job "cgroup" {
-  type = "sysbatch"
+  type = "batch"
 
   group "group" {
     task "cat" {

--- a/hack/curl.hcl
+++ b/hack/curl.hcl
@@ -1,6 +1,5 @@
 job "curl" {
-  datacenters = ["dc1"]
-  type        = "batch"
+  type = "batch"
 
   group "group" {
     task "curl" {

--- a/hack/env.hcl
+++ b/hack/env.hcl
@@ -1,6 +1,5 @@
 job "env" {
-  datacenters = ["dc1"]
-  type        = "sysbatch"
+  type = "batch"
 
   group "group" {
     task "env" {

--- a/hack/http.hcl
+++ b/hack/http.hcl
@@ -1,11 +1,8 @@
 job "http" {
-  datacenters = ["dc1"]
-  type        = "service"
-
   group "group" {
     network {
       mode = "host"
-      port "http" { static = "8181" }
+      port "http" { static = 8181 }
     }
 
     task "task" {
@@ -37,7 +34,7 @@ EOH
     }
 
     update {
-      min_healthy_time = "1s"
+      min_healthy_time = "2s"
     }
   }
 }

--- a/hack/ignore.hcl
+++ b/hack/ignore.hcl
@@ -1,7 +1,4 @@
 job "ignore" {
-  datacenters = ["dc1"]
-  type        = "service"
-
   group "group" {
     task "ignore" {
       driver       = "pledge"
@@ -34,7 +31,7 @@ EOH
     }
 
     update {
-      min_healthy_time = "1s"
+      min_healthy_time = "2s"
     }
   }
 }

--- a/hack/passwd.hcl
+++ b/hack/passwd.hcl
@@ -1,10 +1,10 @@
 job "passwd" {
-  datacenters = ["dc1"]
-  type        = "sysbatch"
+  type = "sysbatch"
 
   group "group" {
     task "cat" {
       driver = "pledge"
+      user   = "root"
       config {
         command  = "cat"
         args     = ["/etc/passwd"]

--- a/hack/sleep.hcl
+++ b/hack/sleep.hcl
@@ -1,13 +1,11 @@
 job "sleep" {
-  datacenters = ["dc1"]
-  type        = "sysbatch"
-
   group "group" {
     task "sleep" {
       driver = "pledge"
+      user   = "nobody"
       config {
         command    = "sleep"
-        args       = ["1d"]
+        args       = ["infinity"]
         promises   = "stdio rpath"
         importance = "lowest"
       }


### PR DESCRIPTION
Use batch instead of sysbatch, because deployments make the e2e tests
work more reliably. No need to specify dc anymore. Run nomad fmt on
all the files.
