### PR TITLE
plugin: correctly set memory resource constriants in cgroup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 GOTAGS ?= osusergo
 
+default: dev
+
 .PHONY: clean
 clean:
 	@echo "==> Cleanup previous build"
@@ -33,4 +35,3 @@ release: clean
 	envy exec gh-release goreleaser release --clean
 	$(MAKE) clean
 
-default: dev

--- a/hack/client.hcl
+++ b/hack/client.hcl
@@ -1,3 +1,10 @@
+server {
+  enabled = true
+  default_scheduler_config {
+    memory_oversubscription_enabled = true
+  }
+}
+
 client {
   enabled = true
 }

--- a/hack/http.hcl
+++ b/hack/http.hcl
@@ -16,6 +16,11 @@ job "http" {
         importance = "low"
       }
 
+      resources {
+        memory = 128
+        memory_max = 200
+      }
+
       template {
         destination = "local/index.html"
         data        = <<EOH

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -260,15 +260,20 @@ func (p *PledgeDriver) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandl
 		return nil, nil, fmt.Errorf("failed to open log file(s): %w", err)
 	}
 
+	memory := uint64(config.Resources.NomadResources.Memory.MemoryMB) * 1024 * 1024
+	memoryMax := uint64(config.Resources.NomadResources.Memory.MemoryMaxMB) * 1024 * 1024
+
 	// create the environment for pledge
 	env := &pledge.Environment{
-		Out:    stdout,
-		Err:    stderr,
-		Env:    config.Env,
-		Dir:    config.TaskDir().Dir,
-		User:   config.User,
-		Cgroup: p.cgroup(config.AllocID, config.Name),
-		Net:    netns(config),
+		Out:       stdout,
+		Err:       stderr,
+		Env:       config.Env,
+		Dir:       config.TaskDir().Dir,
+		User:      config.User,
+		Cgroup:    p.cgroup(config.AllocID, config.Name),
+		Net:       netns(config),
+		Memory:    memory,
+		MemoryMax: memoryMax,
 	}
 
 	opts, err := parseOptions(config)


### PR DESCRIPTION
If memory is set but memory_max is not set in task resources, apply
memory (bytes) to the memory.max cgroup interface file.

Otherwise memory is set and memory_max is set, apply memory to the
memory.low cgroup file and apply memory_max to the memory.max file.

Fixes #58